### PR TITLE
Initial version of enable-fips-mode

### DIFF
--- a/enable-fips-mode/main.fmf
+++ b/enable-fips-mode/main.fmf
@@ -1,0 +1,9 @@
+summary: Enable FIPS 140 mode
+description: ''
+enabled: true
+contact: Ondrej Moris <omoris@redhat.com>
+test: ./runtest.sh
+framework: beakerlib
+require:
+  - library(crypto/fips)
+duration: 15m

--- a/enable-fips-mode/runtest.sh
+++ b/enable-fips-mode/runtest.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /enable-fips-mode
+#   Description: Enable FIPS 140 mode.
+#   Author: Ondrej Moris <omoris@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2023 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh
+
+rlJournalStart
+
+    rlPhaseStartSetup
+        rlRun "rlImport /crypto/fips" || rlDie
+    
+        if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then
+            if ! fipsIsSupported; then
+                rlFail "FIPS 140 mode is not supported on this machine!"
+                rlPhaseEnd
+                rlJournalPrintText                
+                rlJournalEnd
+                exit 0
+            fi
+
+            if fipsIsEnabled; then
+                rlPass "FIPS 140 mode is already enabled!"
+                rlPhaseEnd
+                rlJournalPrintText                
+                rlJournalEnd
+                exit 0
+            fi
+            
+            rlRun "fipsEnable"
+            
+            # Umount common mountpoints to prevent mount locking.
+            rlCheckMountQa && rlRun "umount -l /mnt/qa"
+            rlCheckMountRedhat && rlRun "umount -l /mnt/redhat"
+            rlCheckMountEngarchive && rlRun "umount -l /mnt/engarchive /mnt/engarchive2"
+
+            rlPhaseEnd
+            tmt-reboot
+        else
+            rlRun "fipsIsEnabled"
+        fi
+    rlPhaseEnd
+
+rlJournalPrintText
+
+rlJournalEnd

--- a/fips/lib.sh
+++ b/fips/lib.sh
@@ -48,21 +48,41 @@ will produce an error.
 #   Internal Functions and Variabled
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Directory with this library.
-_fipsLIBDIR=""
-
 function _workarounds {
 
     local ret_val=0 
 
-    if rlIsRHEL ">=8"; then
+    if rlIsRHEL ">=8" && [ -d /usr/share/restraint ]; then
 
         # On RHEL-8, rpm cannot verify digests of rpms using MD5 digest in FIPS 140.
         # Unfortunately, older test rpms are do not have neither SHA1 nor SHA256 and
         # hence cannot be installed. Test installation si done by restraint and we 
         # have to workaround it not to check digests.
-        rlRun "cp ${_fipsLIBDIR}/rstrnt-package-workaround.sh /usr/local/bin && \
-               chmod a+x /usr/local/bin/rstrnt-package-workaround.sh && \
+        cat >/usr/local/bin/rstrnt-package-workaround.sh<<EOF
+#!/bin/bash
+
+tmp_dir=$(mktemp -d)
+
+shift
+operation=$1
+shift 
+packages=$*
+
+if [[ "$operation" == "remove" ]]; then
+
+    dnf remove -y $packages
+    
+elif [[ "$operation" == "install" ]]; then
+
+    pushd $tmp_dir 
+    dnf install --downloadonly -y --downloaddir . --skip-broken $packages
+    rpm -Uhv --nodigest --nofiledigest --nodeps *.rpm
+    popd
+fi
+
+rm -rf $tmp_dir
+EOF
+        rlRun "chmod a+x /usr/local/bin/rstrnt-package-workaround.sh && \
                echo 'RSTRNT_PKG_CMD=/usr/local/bin/rstrnt-package-workaround.sh' >/usr/share/restraint/pkg_commands.d/rhel" 0 \
               "Apply workaround for installation test rpms with MD5 digest" || ret_val=1
     fi
@@ -477,8 +497,6 @@ fully enabled) FIPS 140 mode will produce an error.
 
 =cut
 function fipsLibraryLoaded {
-
-    _fipsLIBDIR="/mnt/tests/distribution/Library/fips/"
 
     # In Fedora, fips-mode-setup is separate package, but cannot 
     # be installed via fips library dependecies.


### PR DESCRIPTION
We want to have an upstream version of our internal setup-fips-enabled task to turn on the FIPS mode. It also requires one cosmetic fix in fips library that is already present in crypto git.