### PR TITLE
Make restraint workaround more robust

### DIFF
--- a/fips/lib.sh
+++ b/fips/lib.sh
@@ -63,7 +63,7 @@ function _workarounds {
         cat >/usr/local/bin/rstrnt-package-workaround.sh<<EOF
 #!/bin/bash
 
-tmp_dir=$(mktemp -d)
+tmp_dir=\$(mktemp -d)
 
 shift
 operation=\$1

--- a/fips/runtest.sh
+++ b/fips/runtest.sh
@@ -63,8 +63,11 @@ rlJournalStart
             # Now, FIPS mode is enabled.
             rlRun "fipsIsEnabled" 0
 
-            # Packages can be installed.
+            # Packages can be installed and removed.
             rlRun "rstrnt-package install libreswan" 0
+            rlAssertRpm "libreswan"
+            rlRun "rstrnt-package remove libreswan" 0
+            rlAssertNotRpm "libreswan"
 
             rlRun "rm -f /var/tmp/fips-reboot" 0
 


### PR DESCRIPTION
On system with restraint packages are installed and removed using custom wrapper. There was a minor issue cause that this workaround used the same temporary directory for every invocation. That is not always bad but the original intention was to use different directory every time. Moreover, we are sligthly extending self-test.