### PR TITLE
ubuntu: report disabled FIPS

### DIFF
--- a/fips/lib.sh
+++ b/fips/lib.sh
@@ -324,6 +324,10 @@ function fipsIsEnabled {
             ret_val=1;
         fi
 
+    elif rlIsOS "ubuntu"; then
+
+            ret_val=1
+
     else
         rlLogError "Unsupported distro!"
     fi


### PR DESCRIPTION
I need to use fips library in upstream NSS CI, which is currently using Ubuntu containers.